### PR TITLE
Regex fixes for compound name parsing

### DIFF
--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -365,6 +365,8 @@ class Reaction:
         line = self.__removeTabs(line)
         line, specific_info = self.__extractDataField(line, ("{", ".*}"))
         line, meta = self.__extractDataField(line, ("\(", ".*\)"))
+        line, meta_pipe = self.__extractDataField(line, ("\|", "\|"))
+        meta += meta_pipe
         line, refs = self.__extractDataField(line, ("<", ">"))
         line, species = self.__extractDataField(line, ("#", "#"))
         if numeric_value:
@@ -385,6 +387,8 @@ class Reaction:
         """
         line = self.__removeTabs(line)
         line, meta = self.__extractDataField(line, ("\(", ".*\)"))
+        line, meta_pipe = self.__extractDataField(line, ("\|", "\|"))
+        meta += meta_pipe
         rxn_str = line.strip()
         meta_list = []
         for meta_line in meta.split(";"):

--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -372,7 +372,6 @@ class Reaction:
             value = self.__eval_range_value(line.strip())
         else:
             value = line.strip()
-        print(f"meta: {meta}")
         return {
             "value": value,
             "species": species.split(","),

--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -567,8 +567,8 @@ class Reaction:
             )
             try:
                 subs, prods = rxn.split("=")
-                subs = [s.strip() for s in subs.split("+") if s.strip() != ""]
-                prods = [s.strip() for s in prods.split("+") if s.strip() != ""]
+                subs = [s.strip() for s in subs.split(" + ") if s.strip() != ""]
+                prods = [s.strip() for s in prods.split(" + ") if s.strip() != ""]
                 subs.sort()
                 prods.sort()
                 if subs not in substrates and len(subs) > 0 and len(prods) > 0:

--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -332,7 +332,7 @@ class Reaction:
             left, right = regex_tags
             searched_s = re.search(f"{left}(.+?){right}", line)
             matched_s = searched_s.group().strip()[1:-1]
-            line = line.replace(f"{matched_s}", "")
+            line = line.replace(f"{searched_s.group()}", "")
             return (line, matched_s)
         except Exception:
             return (line, "")

--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -331,7 +331,7 @@ class Reaction:
         try:
             left, right = regex_tags
             searched_s = re.search(f"{left}(.+?){right}", line)
-            matched_s = searched_s.group().strip()
+            matched_s = searched_s.group().strip()[1:-1]
             line = line.replace(f"{matched_s}", "")
             return (line, matched_s)
         except Exception:

--- a/src/brendapyrser/parser.py
+++ b/src/brendapyrser/parser.py
@@ -331,9 +331,8 @@ class Reaction:
         try:
             left, right = regex_tags
             searched_s = re.search(f"{left}(.+?){right}", line)
-            span = searched_s.span()
-            matched_s = line[span[0] + 1 : span[1] - 1].strip()
-            line = line.replace(f"{searched_s.group()}", "")
+            matched_s = searched_s.group().strip()
+            line = line.replace(f"{matched_s}", "")
             return (line, matched_s)
         except Exception:
             return (line, "")
@@ -364,7 +363,7 @@ class Reaction:
         """
         line = self.__removeTabs(line)
         line, specific_info = self.__extractDataField(line, ("{", ".*}"))
-        line, meta = self.__extractDataField(line, ("\(", ".*\)"))
+        line, meta = self.__extractDataField(line, ("\s+\(", ".*\)"))
         line, meta_pipe = self.__extractDataField(line, ("\|", "\|"))
         meta += meta_pipe
         line, refs = self.__extractDataField(line, ("<", ">"))
@@ -373,6 +372,7 @@ class Reaction:
             value = self.__eval_range_value(line.strip())
         else:
             value = line.strip()
+        print(f"meta: {meta}")
         return {
             "value": value,
             "species": species.split(","),


### PR DESCRIPTION
Hello! Thank you so much for your work on BRENDApyrser. I was using it for a study and found a few issues.

1. Splitting on the "+" character to parse out the reactions was also getting rid of +s indicating that a compound was a positive ion, e.g. H+. I changed `substratesAndProducts` to only split on "+" if there are spaces around it and leave +s in compound names.
2. Comments inside pipe | characters were being left in the compound name instead of being added to the meta field. I added them to the meta field in `__extractDataField` and `__extractReactionMechanismInfo`.
3. Issue #12 mentions compound names being wrongly parsed when they contain parentheses. This is because the parser was extracting the first match of something in parentheses and putting that in the meta field. I changed `extractDataLineInfo` to only add something in parentheses to the meta field if it starts with whitespace.

These worked for me, but there are definitely better ways to do them, so feel free to suggest changes. Thanks again!